### PR TITLE
feat: add OpenTelemetry integration with alerting support

### DIFF
--- a/alerting/README.md
+++ b/alerting/README.md
@@ -1,0 +1,156 @@
+# OpenTelemetry 报警配置说明
+
+## 架构概述
+
+```
+┌─────────────┐    ┌─────────────────┐    ┌──────────────┐
+│  Web App    │───▶│  OTel Collector │───▶│ Elasticsearch│
+│ (Browser)   │    │                 │    │   (存储)      │
+└─────────────┘    │   ┌──────────┐  │    └──────────────┘
+                   │   │spanmetrics│  │           │
+                   │   └────┬─────┘  │           ▼
+                   └────────┼────────┘    ┌──────────────┐
+                            │             │  ES Watcher  │
+                            ▼             │   (报警)      │
+                   ┌─────────────┐        └──────────────┘
+                   │ Prometheus  │
+                   │  (metrics)  │
+                   └──────┬──────┘
+                          │
+                          ▼
+                   ┌─────────────┐
+                   │Alertmanager │
+                   │   (通知)     │
+                   └─────────────┘
+```
+
+## 报警方案选择
+
+### 方案一：Elasticsearch Watcher (推荐)
+
+如果你的数据已经在 ES 中，使用 ES Watcher 是最简单的方案：
+
+1. **优点**：
+   - 无需额外组件
+   - 直接查询原始 trace 数据
+   - 配置简单
+
+2. **配置步骤**：
+   ```bash
+   # 创建 Watcher
+   curl -X PUT "localhost:9200/_watcher/watch/high_error_rate" \
+     -H 'Content-Type: application/json' \
+     -d @elasticsearch-watcher.json
+   ```
+
+### 方案二：Prometheus + Alertmanager
+
+适合已有 Prometheus 监控体系的场景：
+
+1. **优点**：
+   - 强大的查询语言 PromQL
+   - 丰富的报警规则
+   - 与 Grafana 集成良好
+
+2. **配置步骤**：
+   ```bash
+   # 启动 Prometheus
+   prometheus --config.file=prometheus.yml \
+     --storage.tsdb.path=/data/prometheus
+
+   # 启动 Alertmanager
+   alertmanager --config.file=alertmanager-config.yaml
+   ```
+
+## 报警规则说明
+
+| 报警名称 | 触发条件 | 严重级别 |
+|---------|---------|---------|
+| HighErrorRate | 错误率 > 5% | Critical |
+| HighLatency | P95 延迟 > 2s | Warning |
+| AIServiceFailure | AI调用失败率 > 10% | Critical |
+| SlowPageLoad | P90 页面加载 > 3s | Warning |
+| OtelCollectorDown | Collector 不可用 | Critical |
+
+## 快速开始
+
+### 1. 部署 OpenTelemetry Collector
+
+```bash
+docker run -d --name otel-collector \
+  -p 4317:4317 -p 4318:4318 -p 8889:8889 \
+  -v $(pwd)/otel-collector-config.yaml:/etc/otel/config.yaml \
+  -e ELASTICSEARCH_URL=http://your-es:9200 \
+  otel/opentelemetry-collector-contrib:latest \
+  --config=/etc/otel/config.yaml
+```
+
+### 2. 配置 ES Watcher
+
+```bash
+# 启用 Watcher 功能（X-Pack）
+curl -X PUT "localhost:9200/_watcher/watch/high_error_rate" \
+  -H 'Content-Type: application/json' \
+  -d @elasticsearch-watcher.json
+```
+
+### 3. 配置 Slack Webhook
+
+1. 创建 Slack App: https://api.slack.com/apps
+2. 添加 Incoming Webhook
+3. 设置环境变量:
+   ```bash
+   export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx
+   ```
+
+## 自定义报警
+
+### 添加新的 ES Watcher 报警
+
+```json
+{
+  "trigger": {
+    "schedule": { "interval": "5m" }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "indices": ["otel-traces-*"],
+        "body": {
+          "query": { "your_query": {} }
+        }
+      }
+    }
+  },
+  "condition": {
+    "compare": { "ctx.payload.hits.total.value": { "gt": 100 } }
+  },
+  "actions": {
+    "notify": { "webhook": { ... } }
+  }
+}
+```
+
+### 添加新的 Prometheus 报警规则
+
+```yaml
+- alert: CustomAlert
+  expr: your_metric_query > threshold
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "自定义报警"
+    description: "描述信息"
+```
+
+## 常见问题
+
+**Q: 数据在 ES 中，但报警不触发？**
+A: 检查 ES Watcher 是否启用，以及索引名是否正确。
+
+**Q: 如何调整报警阈值？**
+A: 修改对应配置文件中的阈值参数，然后重新加载配置。
+
+**Q: 支持哪些通知渠道？**
+A: Slack、Email、PagerDuty、Webhook、企业微信、钉钉等。

--- a/alerting/alertmanager-config.yaml
+++ b/alerting/alertmanager-config.yaml
@@ -1,0 +1,124 @@
+# Alertmanager 配置
+# 用于接收 Prometheus 报警并发送通知
+
+global:
+  # 全局配置
+  resolve_timeout: 5m
+
+  # SMTP 配置（邮件通知）
+  smtp_smarthost: 'smtp.example.com:587'
+  smtp_from: 'alertmanager@example.com'
+  smtp_auth_username: '${SMTP_USER}'
+  smtp_auth_password: '${SMTP_PASSWORD}'
+  smtp_require_tls: true
+
+  # Slack 配置
+  slack_api_url: '${SLACK_WEBHOOK_URL}'
+
+# 路由配置
+route:
+  # 默认接收者
+  receiver: 'default-receiver'
+
+  # 分组规则
+  group_by: ['alertname', 'severity', 'service_name']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+  # 子路由
+  routes:
+    # Critical 级别报警
+    - match:
+        severity: critical
+      receiver: 'critical-receiver'
+      group_wait: 10s
+      repeat_interval: 1h
+
+    # Warning 级别报警
+    - match:
+        severity: warning
+      receiver: 'warning-receiver'
+      group_wait: 1m
+      repeat_interval: 4h
+
+    # AI 团队相关报警
+    - match:
+        team: ai-platform
+      receiver: 'ai-team-receiver'
+
+    # 基础设施报警
+    - match:
+        team: infrastructure
+      receiver: 'infra-receiver'
+
+# 接收者配置
+receivers:
+  - name: 'default-receiver'
+    slack_configs:
+      - channel: '#alerts-default'
+        send_resolved: true
+        title: '{{ template "slack.default.title" . }}'
+        text: '{{ template "slack.default.text" . }}'
+
+  - name: 'critical-receiver'
+    slack_configs:
+      - channel: '#alerts-critical'
+        send_resolved: true
+        title: '🚨 Critical Alert: {{ .CommonAnnotations.summary }}'
+        text: |
+          *Alert:* {{ .CommonAnnotations.summary }}
+          *Description:* {{ .CommonAnnotations.description }}
+          *Severity:* {{ .CommonLabels.severity }}
+          *Service:* {{ .CommonLabels.service_name }}
+    email_configs:
+      - to: 'oncall@example.com'
+        send_resolved: true
+    # 可选：电话通知（通过 PagerDuty）
+    # pagerduty_configs:
+    #   - service_key: '${PAGERDUTY_KEY}'
+    #     severity: critical
+
+  - name: 'warning-receiver'
+    slack_configs:
+      - channel: '#alerts-warning'
+        send_resolved: true
+        title: '⚠️ Warning: {{ .CommonAnnotations.summary }}'
+        text: |
+          *Alert:* {{ .CommonAnnotations.summary }}
+          *Description:* {{ .CommonAnnotations.description }}
+          *Severity:* {{ .CommonLabels.severity }}
+
+  - name: 'ai-team-receiver'
+    slack_configs:
+      - channel: '#ai-platform-alerts'
+        send_resolved: true
+    email_configs:
+      - to: 'ai-team@example.com'
+
+  - name: 'infra-receiver'
+    slack_configs:
+      - channel: '#infrastructure-alerts'
+        send_resolved: true
+    email_configs:
+      - to: 'infra-team@example.com'
+
+# 抑制规则
+inhibit_rules:
+  # Critical 抑制 Warning
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname', 'service_name']
+
+  # Collector down 抑制导出失败
+  - source_match:
+      alertname: 'OtelCollectorDown'
+    target_match:
+      alertname: 'OtelExportFailure'
+    equal: ['instance']
+
+# 模板文件
+templates:
+  - '/etc/alertmanager/templates/*.tmpl'

--- a/alerting/elasticsearch-watcher.json
+++ b/alerting/elasticsearch-watcher.json
@@ -1,0 +1,262 @@
+{
+  "description": "基于 Elasticsearch 的 OpenTelemetry 数据报警配置",
+  "watchers": [
+    {
+      "name": "high_error_rate_watcher",
+      "description": "高错误率报警 - 当5分钟内错误率超过5%时触发",
+      "trigger": {
+        "schedule": {
+          "interval": "1m"
+        }
+      },
+      "input": {
+        "search": {
+          "request": {
+            "indices": ["otel-traces-*"],
+            "body": {
+              "size": 0,
+              "query": {
+                "bool": {
+                  "must": [
+                    {
+                      "range": {
+                        "@timestamp": {
+                          "gte": "now-5m"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "aggs": {
+                "by_status": {
+                  "terms": {
+                    "field": "status.code"
+                  }
+                },
+                "total_spans": {
+                  "value_count": {
+                    "field": "traceId"
+                  }
+                },
+                "error_spans": {
+                  "filter": {
+                    "term": {
+                      "status.code": "ERROR"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "condition": {
+        "script": {
+          "source": "return ctx.payload.aggregations.error_spans.doc_count > 0 && (ctx.payload.aggregations.error_spans.doc_count / ctx.payload.aggregations.total_spans.value) > 0.05"
+        }
+      },
+      "actions": {
+        "send_slack": {
+          "webhook": {
+            "scheme": "https",
+            "host": "hooks.slack.com",
+            "port": 443,
+            "method": "POST",
+            "path": "/services/${SLACK_WEBHOOK_PATH}",
+            "body": "{{#toJson}}{'text': '🚨 高错误率报警: 过去5分钟错误率为 {{ctx.payload.aggregations.error_spans.doc_count}}/{{ctx.payload.aggregations.total_spans.value}}'}{{/toJson}}"
+          }
+        },
+        "send_email": {
+          "email": {
+            "to": "oncall@example.com",
+            "subject": "[ALERT] 高错误率报警",
+            "body": {
+              "text": "过去5分钟内检测到高错误率。\n错误数: {{ctx.payload.aggregations.error_spans.doc_count}}\n总请求数: {{ctx.payload.aggregations.total_spans.value}}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "slow_api_response_watcher",
+      "description": "API响应时间过长报警",
+      "trigger": {
+        "schedule": {
+          "interval": "2m"
+        }
+      },
+      "input": {
+        "search": {
+          "request": {
+            "indices": ["otel-traces-*"],
+            "body": {
+              "size": 0,
+              "query": {
+                "bool": {
+                  "must": [
+                    {
+                      "range": {
+                        "@timestamp": {
+                          "gte": "now-5m"
+                        }
+                      }
+                    },
+                    {
+                      "term": {
+                        "kind": "CLIENT"
+                      }
+                    }
+                  ]
+                }
+              },
+              "aggs": {
+                "avg_duration": {
+                  "avg": {
+                    "field": "duration"
+                  }
+                },
+                "p95_duration": {
+                  "percentiles": {
+                    "field": "duration",
+                    "percents": [95]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "condition": {
+        "script": {
+          "source": "return ctx.payload.aggregations.p95_duration.values['95.0'] > 2000000000"
+        }
+      },
+      "actions": {
+        "send_slack": {
+          "webhook": {
+            "scheme": "https",
+            "host": "hooks.slack.com",
+            "port": 443,
+            "method": "POST",
+            "path": "/services/${SLACK_WEBHOOK_PATH}",
+            "body": "{{#toJson}}{'text': '⚠️ API响应时间过长: P95延迟超过2秒'}{{/toJson}}"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai_service_failure_watcher",
+      "description": "AI服务调用失败报警",
+      "trigger": {
+        "schedule": {
+          "interval": "1m"
+        }
+      },
+      "input": {
+        "search": {
+          "request": {
+            "indices": ["otel-traces-*"],
+            "body": {
+              "size": 0,
+              "query": {
+                "bool": {
+                  "must": [
+                    {
+                      "range": {
+                        "@timestamp": {
+                          "gte": "now-5m"
+                        }
+                      }
+                    },
+                    {
+                      "wildcard": {
+                        "name": "ai.*"
+                      }
+                    }
+                  ]
+                }
+              },
+              "aggs": {
+                "total_ai_calls": {
+                  "value_count": {
+                    "field": "traceId"
+                  }
+                },
+                "failed_ai_calls": {
+                  "filter": {
+                    "term": {
+                      "status.code": "ERROR"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "condition": {
+        "script": {
+          "source": "return ctx.payload.aggregations.total_ai_calls.value > 0 && (ctx.payload.aggregations.failed_ai_calls.doc_count / ctx.payload.aggregations.total_ai_calls.value) > 0.1"
+        }
+      },
+      "actions": {
+        "send_slack": {
+          "webhook": {
+            "scheme": "https",
+            "host": "hooks.slack.com",
+            "port": 443,
+            "method": "POST",
+            "path": "/services/${SLACK_WEBHOOK_PATH}",
+            "body": "{{#toJson}}{'text': '🚨 AI服务调用失败率过高: 失败率超过10%，请检查Gemini API状态'}{{/toJson}}"
+          }
+        }
+      }
+    },
+    {
+      "name": "no_data_watcher",
+      "description": "无数据报警 - 当10分钟内没有收到任何trace数据时触发",
+      "trigger": {
+        "schedule": {
+          "interval": "5m"
+        }
+      },
+      "input": {
+        "search": {
+          "request": {
+            "indices": ["otel-traces-*"],
+            "body": {
+              "size": 0,
+              "query": {
+                "range": {
+                  "@timestamp": {
+                    "gte": "now-10m"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "condition": {
+        "compare": {
+          "ctx.payload.hits.total.value": {
+            "eq": 0
+          }
+        }
+      },
+      "actions": {
+        "send_slack": {
+          "webhook": {
+            "scheme": "https",
+            "host": "hooks.slack.com",
+            "port": 443,
+            "method": "POST",
+            "path": "/services/${SLACK_WEBHOOK_PATH}",
+            "body": "{{#toJson}}{'text': '⚠️ 无数据报警: 过去10分钟未收到任何遥测数据，请检查OpenTelemetry Collector状态'}{{/toJson}}"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/alerting/prometheus-alerts.yaml
+++ b/alerting/prometheus-alerts.yaml
@@ -1,0 +1,110 @@
+# Prometheus 报警规则配置
+# 基于 OpenTelemetry Collector 导出的 metrics 进行报警
+
+groups:
+  - name: otel-web-app-alerts
+    rules:
+      # 高错误率报警
+      - alert: HighErrorRate
+        expr: |
+          sum(rate(otel_span_status_code{status_code="ERROR"}[5m]))
+          / sum(rate(otel_span_status_code[5m])) > 0.05
+        for: 2m
+        labels:
+          severity: critical
+          team: frontend
+        annotations:
+          summary: "高错误率报警"
+          description: "服务 {{ $labels.service_name }} 错误率超过 5%，当前值: {{ $value | humanizePercentage }}"
+
+      # API 响应时间过长
+      - alert: HighLatency
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(otel_span_duration_milliseconds_bucket{span_kind="CLIENT"}[5m])) by (le, service_name)
+          ) > 2000
+        for: 3m
+        labels:
+          severity: warning
+          team: frontend
+        annotations:
+          summary: "API 响应时间过长"
+          description: "服务 {{ $labels.service_name }} P95 延迟超过 2s，当前值: {{ $value }}ms"
+
+      # AI 服务调用失败
+      - alert: AIServiceFailure
+        expr: |
+          sum(rate(otel_span_status_code{span_name=~"ai.*", status_code="ERROR"}[5m]))
+          / sum(rate(otel_span_status_code{span_name=~"ai.*"}[5m])) > 0.1
+        for: 1m
+        labels:
+          severity: critical
+          team: ai-platform
+        annotations:
+          summary: "AI 服务调用失败率过高"
+          description: "AI 服务失败率超过 10%，当前值: {{ $value | humanizePercentage }}"
+
+      # 请求量异常
+      - alert: RequestVolumeAnomaly
+        expr: |
+          abs(sum(rate(otel_span_duration_milliseconds_count[5m]))
+          - sum(rate(otel_span_duration_milliseconds_count[5m] offset 1h)))
+          / sum(rate(otel_span_duration_milliseconds_count[5m] offset 1h)) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+          team: frontend
+        annotations:
+          summary: "请求量异常波动"
+          description: "请求量相比1小时前变化超过 50%"
+
+      # 页面加载时间过长
+      - alert: SlowPageLoad
+        expr: |
+          histogram_quantile(0.90,
+            sum(rate(otel_span_duration_milliseconds_bucket{span_name="documentLoad"}[5m])) by (le)
+          ) > 3000
+        for: 5m
+        labels:
+          severity: warning
+          team: frontend
+        annotations:
+          summary: "页面加载时间过长"
+          description: "P90 页面加载时间超过 3s，当前值: {{ $value }}ms"
+
+  - name: otel-infrastructure-alerts
+    rules:
+      # Collector 健康检查
+      - alert: OtelCollectorDown
+        expr: up{job="otel-collector"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          team: infrastructure
+        annotations:
+          summary: "OpenTelemetry Collector 不可用"
+          description: "Collector 实例 {{ $labels.instance }} 已停止"
+
+      # 导出失败
+      - alert: OtelExportFailure
+        expr: |
+          rate(otelcol_exporter_send_failed_spans_total[5m]) > 0
+        for: 2m
+        labels:
+          severity: warning
+          team: infrastructure
+        annotations:
+          summary: "遥测数据导出失败"
+          description: "Exporter {{ $labels.exporter }} 导出失败，失败率: {{ $value }}/s"
+
+      # 队列积压
+      - alert: OtelQueueBacklog
+        expr: |
+          otelcol_processor_batch_batch_send_size > 1000
+        for: 5m
+        labels:
+          severity: warning
+          team: infrastructure
+        annotations:
+          summary: "遥测数据队列积压"
+          description: "批处理队列大小: {{ $value }}"

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -1,0 +1,123 @@
+# OpenTelemetry Collector 配置
+# 负责接收、处理和导出遥测数据到 Elasticsearch
+# 同时配置 Prometheus 导出用于报警
+
+receivers:
+  # OTLP 接收器 - 接收前端发送的遥测数据
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+        cors:
+          allowed_origins:
+            - "*"
+          allowed_headers:
+            - "*"
+
+processors:
+  # 批处理器 - 优化数据发送
+  batch:
+    timeout: 1s
+    send_batch_size: 1024
+    send_batch_max_size: 2048
+
+  # 内存限制器 - 防止 OOM
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+
+  # 属性处理器 - 添加额外属性用于报警
+  attributes:
+    actions:
+      - key: alert.enabled
+        value: true
+        action: upsert
+
+connectors:
+  # Span 转 Metrics 连接器 - 从 traces 生成 metrics 用于报警
+  spanmetrics:
+    histogram:
+      explicit:
+        buckets: [10ms, 50ms, 100ms, 250ms, 500ms, 1s, 2s, 5s, 10s]
+    dimensions:
+      - name: http.method
+      - name: http.status_code
+      - name: service.name
+    exemplars:
+      enabled: true
+    metrics_flush_interval: 15s
+
+exporters:
+  # Elasticsearch 导出器 - 存储 traces 数据
+  elasticsearch:
+    endpoints:
+      - ${ELASTICSEARCH_URL:http://localhost:9200}
+    traces_index: otel-traces
+    logs_index: otel-logs
+    user: ${ELASTICSEARCH_USER:}
+    password: ${ELASTICSEARCH_PASSWORD:}
+    tls:
+      insecure: true
+    retry:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 30s
+      max_elapsed_time: 300s
+
+  # Prometheus 导出器 - 用于报警
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: otel
+    const_labels:
+      app: retro-camera
+
+  # 日志导出器 - 调试用
+  logging:
+    verbosity: detailed
+    sampling_initial: 5
+    sampling_thereafter: 200
+
+extensions:
+  # 健康检查
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+  # pprof 性能分析
+  pprof:
+    endpoint: 0.0.0.0:1777
+
+  # zpages 调试页面
+  zpages:
+    endpoint: 0.0.0.0:55679
+
+service:
+  extensions: [health_check, pprof, zpages]
+
+  pipelines:
+    # Traces 管道 - 发送到 ES 和 spanmetrics
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, attributes]
+      exporters: [elasticsearch, spanmetrics, logging]
+
+    # Metrics 管道 - 从 spanmetrics 读取，发送到 Prometheus
+    metrics:
+      receivers: [spanmetrics]
+      processors: [memory_limiter, batch]
+      exporters: [prometheus]
+
+    # Logs 管道
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [elasticsearch, logging]
+
+  telemetry:
+    logs:
+      level: info
+    metrics:
+      level: detailed
+      address: 0.0.0.0:8888

--- a/package.json
+++ b/package.json
@@ -13,7 +13,16 @@
     "react-dom": "^18.3.1",
     "framer-motion": "^11.5.4",
     "lucide-react": "^0.441.0",
-    "html2canvas": "^1.4.1"
+    "html2canvas": "^1.4.1",
+    "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/sdk-trace-web": "^1.21.0",
+    "@opentelemetry/sdk-trace-base": "^1.21.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.48.0",
+    "@opentelemetry/context-zone": "^1.21.0",
+    "@opentelemetry/instrumentation": "^0.48.0",
+    "@opentelemetry/auto-instrumentations-web": "^0.36.0",
+    "@opentelemetry/resources": "^1.21.0",
+    "@opentelemetry/semantic-conventions": "^1.21.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.5",

--- a/src/telemetry/custom-spans.js
+++ b/src/telemetry/custom-spans.js
@@ -1,0 +1,158 @@
+/**
+ * 自定义 Span 创建工具
+ * 用于手动创建遥测数据，支持关键业务指标监控
+ */
+
+import { trace, SpanStatusCode, context } from '@opentelemetry/api';
+
+const tracer = trace.getTracer('retro-camera-custom');
+
+/**
+ * 创建拍照操作的 Span
+ * @param {Function} operation - 要执行的操作
+ * @param {Object} attributes - 额外属性
+ */
+export async function tracePhotoCapture(operation, attributes = {}) {
+  return tracer.startActiveSpan('photo.capture', async (span) => {
+    try {
+      span.setAttributes({
+        'photo.operation': 'capture',
+        'photo.timestamp': Date.now(),
+        ...attributes,
+      });
+
+      const result = await operation();
+
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error.message,
+      });
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * 创建 AI 生成字幕的 Span
+ * @param {Function} operation - 要执行的操作
+ * @param {Object} attributes - 额外属性
+ */
+export async function traceAICaption(operation, attributes = {}) {
+  return tracer.startActiveSpan('ai.caption.generate', async (span) => {
+    const startTime = Date.now();
+
+    try {
+      span.setAttributes({
+        'ai.provider': 'gemini',
+        'ai.operation': 'caption_generation',
+        ...attributes,
+      });
+
+      const result = await operation();
+
+      span.setAttributes({
+        'ai.duration_ms': Date.now() - startTime,
+        'ai.success': true,
+      });
+      span.setStatus({ code: SpanStatusCode.OK });
+
+      return result;
+    } catch (error) {
+      span.setAttributes({
+        'ai.duration_ms': Date.now() - startTime,
+        'ai.success': false,
+        'ai.error': error.message,
+      });
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error.message,
+      });
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * 创建用户交互 Span
+ * @param {string} action - 操作名称
+ * @param {Function} operation - 要执行的操作
+ * @param {Object} attributes - 额外属性
+ */
+export async function traceUserInteraction(action, operation, attributes = {}) {
+  return tracer.startActiveSpan(`user.interaction.${action}`, async (span) => {
+    try {
+      span.setAttributes({
+        'user.action': action,
+        'user.timestamp': Date.now(),
+        ...attributes,
+      });
+
+      const result = await operation();
+
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error.message,
+      });
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * 记录错误事件（用于报警）
+ * @param {string} errorType - 错误类型
+ * @param {Error} error - 错误对象
+ * @param {Object} attributes - 额外属性
+ */
+export function recordError(errorType, error, attributes = {}) {
+  const span = trace.getActiveSpan();
+  if (span) {
+    span.recordException(error);
+    span.setAttributes({
+      'error.type': errorType,
+      'error.message': error.message,
+      'error.stack': error.stack,
+      ...attributes,
+    });
+  }
+}
+
+/**
+ * 记录业务指标事件
+ * @param {string} metricName - 指标名称
+ * @param {number} value - 指标值
+ * @param {Object} attributes - 额外属性
+ */
+export function recordMetric(metricName, value, attributes = {}) {
+  const span = trace.getActiveSpan();
+  if (span) {
+    span.addEvent(metricName, {
+      'metric.value': value,
+      'metric.timestamp': Date.now(),
+      ...attributes,
+    });
+  }
+}
+
+export default {
+  tracePhotoCapture,
+  traceAICaption,
+  traceUserInteraction,
+  recordError,
+  recordMetric,
+};

--- a/src/telemetry/otel-config.js
+++ b/src/telemetry/otel-config.js
@@ -1,0 +1,98 @@
+/**
+ * OpenTelemetry 配置文件
+ * 用于前端浏览器端的遥测数据收集和导出
+ */
+
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { ZoneContextManager } from '@opentelemetry/context-zone';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+
+// OpenTelemetry Collector 端点配置
+const OTEL_COLLECTOR_URL = import.meta.env.VITE_OTEL_COLLECTOR_URL || 'http://localhost:4318/v1/traces';
+
+/**
+ * 初始化 OpenTelemetry
+ * @param {Object} config - 配置选项
+ * @param {string} config.serviceName - 服务名称
+ * @param {string} config.serviceVersion - 服务版本
+ * @param {string} config.environment - 环境 (production/staging/development)
+ */
+export function initOpenTelemetry(config = {}) {
+  const {
+    serviceName = 'retro-camera-web-app',
+    serviceVersion = '1.0.0',
+    environment = 'development'
+  } = config;
+
+  // 创建资源信息
+  const resource = new Resource({
+    [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    [SemanticResourceAttributes.SERVICE_VERSION]: serviceVersion,
+    [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: environment,
+  });
+
+  // 创建 OTLP 导出器 - 数据会发送到 Collector，由 Collector 转发到 ES
+  const traceExporter = new OTLPTraceExporter({
+    url: OTEL_COLLECTOR_URL,
+    headers: {
+      // 可以添加认证头
+      // 'Authorization': 'Bearer <token>'
+    },
+  });
+
+  // 创建 Tracer Provider
+  const provider = new WebTracerProvider({
+    resource: resource,
+  });
+
+  // 添加批量 Span 处理器
+  provider.addSpanProcessor(new BatchSpanProcessor(traceExporter, {
+    maxQueueSize: 100,
+    maxExportBatchSize: 10,
+    scheduledDelayMillis: 500,
+    exportTimeoutMillis: 30000,
+  }));
+
+  // 注册 Provider
+  provider.register({
+    contextManager: new ZoneContextManager(),
+  });
+
+  // 注册自动检测
+  registerInstrumentations({
+    instrumentations: [
+      getWebAutoInstrumentations({
+        '@opentelemetry/instrumentation-fetch': {
+          propagateTraceHeaderCorsUrls: [/.*/],
+          clearTimingResources: true,
+        },
+        '@opentelemetry/instrumentation-xml-http-request': {
+          propagateTraceHeaderCorsUrls: [/.*/],
+        },
+        '@opentelemetry/instrumentation-document-load': {},
+        '@opentelemetry/instrumentation-user-interaction': {
+          eventNames: ['click', 'submit'],
+        },
+      }),
+    ],
+  });
+
+  console.log('OpenTelemetry initialized successfully');
+  return provider;
+}
+
+/**
+ * 获取 Tracer 实例
+ * @param {string} name - Tracer 名称
+ */
+export function getTracer(name = 'retro-camera-tracer') {
+  const { trace } = require('@opentelemetry/api');
+  return trace.getTracer(name);
+}
+
+export default initOpenTelemetry;


### PR DESCRIPTION
## Summary
- 添加 OpenTelemetry SDK 浏览器端配置，支持自动追踪和手动 span 创建
- 添加 OpenTelemetry Collector 配置，将 traces 数据导出到 Elasticsearch 和 Prometheus
- 添加完整的报警方案：
  - **Elasticsearch Watcher**: 直接基于 ES 中的 trace 数据进行报警
  - **Prometheus Alertmanager**: 通过 spanmetrics 从 traces 生成 metrics 进行报警
- 支持多种报警规则：高错误率、API 延迟、AI 服务故障、页面加载缓慢等
- 支持多通知渠道：Slack、Email、PagerDuty 等

## 文件说明
| 文件 | 说明 |
|------|------|
| `src/telemetry/otel-config.js` | OpenTelemetry 初始化配置 |
| `src/telemetry/custom-spans.js` | 自定义 span 工具函数 |
| `otel-collector-config.yaml` | Collector 配置（接收、处理、导出） |
| `alerting/prometheus-alerts.yaml` | Prometheus 报警规则 |
| `alerting/alertmanager-config.yaml` | Alertmanager 通知配置 |
| `alerting/elasticsearch-watcher.json` | ES Watcher 报警定义 |
| `alerting/README.md` | 报警配置说明文档 |

## Test plan
- [ ] 验证 OpenTelemetry SDK 正确初始化
- [ ] 验证 Collector 配置文件语法正确
- [ ] 验证报警规则语法正确
- [ ] 部署后测试报警触发和通知